### PR TITLE
fixed typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To create a new project based on this template using
 [degit](https://github.com/Rich-Harris/degit):
 
 ```bash
-npx degit NicoCevalos/svelte-template svelte-app
+npx degit NicoCevallos/svelte-template svelte-app
 cd svelte-app
 ```
 


### PR DESCRIPTION
The installation instructions in the README have a typo (single "l" in username): 

```npx degit NicoCevalos/svelte-template svelte-app```

vs (2 "l" in corrected version)

```npx degit NicoCevallos/svelte-template svelte-app```


This is the PR for the corrected README
